### PR TITLE
Create separate team page

### DIFF
--- a/src/components/about/about.tsx
+++ b/src/components/about/about.tsx
@@ -1,5 +1,6 @@
 import React, { FunctionComponent } from "react";
 import { Flex, Text, Button } from "@chakra-ui/core";
+import { Link as GatsbyLink } from "gatsby";
 
 const descriptionContent =
   "The HKU Machine Learning Society is a group of student developers at The University of Hong Kong collaborating on a number of Machine Learning projects. We go from collecting raw data to developing polished applications that can make a remarkable impact in society. If you are interested in Machine Learning or Software, do not hesitate to join us!";
@@ -18,17 +19,31 @@ export const About: FunctionComponent = () => {
         About
       </Text>
       <Text fontSize={["l", "l", "xl", "xl"]}> {descriptionContent} </Text>
-      <Button
-        backgroundColor="primary"
-        _hover={{ backgroundColor: "secondary" }}
-        textTransform="uppercase"
-        padding="8px 32px"
-        m={5}
-        borderRadius={0}
-        maxWidth={40}
-      >
-        Join Us
-      </Button>
+
+      <Flex pt={2}>
+        <Button
+          padding="8px 32px"
+          backgroundColor="primary"
+          textTransform="uppercase"
+          borderRadius={0}
+          mr={3}
+          _hover={{ backgroundColor: "secondary" }}
+        >
+          Join Us
+        </Button>
+        <GatsbyLink to="/team">
+          <Button
+            padding="8px 32px"
+            backgroundColor="primary"
+            textTransform="uppercase"
+            borderRadius={0}
+            mr={3}
+            _hover={{ backgroundColor: "secondary" }}
+          >
+            The Team
+          </Button>
+        </GatsbyLink>
+      </Flex>
     </Flex>
   );
 };

--- a/src/components/about/about.tsx
+++ b/src/components/about/about.tsx
@@ -31,18 +31,6 @@ export const About: FunctionComponent = () => {
         >
           Join Us
         </Button>
-        <GatsbyLink to="/team">
-          <Button
-            padding="8px 32px"
-            backgroundColor="primary"
-            textTransform="uppercase"
-            borderRadius={0}
-            mr={3}
-            _hover={{ backgroundColor: "secondary" }}
-          >
-            The Team
-          </Button>
-        </GatsbyLink>
       </Flex>
     </Flex>
   );

--- a/src/components/header/header.tsx
+++ b/src/components/header/header.tsx
@@ -6,12 +6,9 @@ import { FiMenu } from "react-icons/fi";
 import { routes } from "./routes";
 import { MobileMenu } from "./mobileMenu";
 
-export const NavItem = ({ text, id, locationHash, isSection }) => (
+export const NavItem = ({ text, id, location, isSection }) => (
   <GatsbyLink to={isSection ? `/#${id}` : `/${id}`} key={id}>
-    <Text
-      color={locationHash === `#${id}` ? "selectedNavColor" : "white"}
-      pr={5}
-    >
+    <Text color={location.endsWith(id) ? "selectedNavColor" : "white"} pr={5}>
       {text}
     </Text>
   </GatsbyLink>
@@ -35,7 +32,7 @@ export const Header: React.FC<{ location: any }> = ({ location }) => {
           <NavItem
             id={route.id}
             text={route.text}
-            locationHash={location.hash}
+            location={location.href}
             key={route.id}
             isSection={route.section}
           ></NavItem>

--- a/src/components/header/header.tsx
+++ b/src/components/header/header.tsx
@@ -6,8 +6,8 @@ import { FiMenu } from "react-icons/fi";
 import { routes } from "./routes";
 import { MobileMenu } from "./mobileMenu";
 
-export const NavItem = ({ text, id, locationHash }) => (
-  <GatsbyLink to={`#${id}`} key={id}>
+export const NavItem = ({ text, id, locationHash, isSection }) => (
+  <GatsbyLink to={isSection ? `/#${id}` : `/${id}`} key={id}>
     <Text
       color={locationHash === `#${id}` ? "selectedNavColor" : "white"}
       pr={5}
@@ -27,7 +27,7 @@ export const Header: React.FC<{ location: any }> = ({ location }) => {
       justifyContent="space-between"
       alignItems="center"
     >
-      <GatsbyLink to="">
+      <GatsbyLink to="/">
         <Heading>HKUMLS</Heading>
       </GatsbyLink>
       <Flex display={["none", "flex"]}>
@@ -37,6 +37,7 @@ export const Header: React.FC<{ location: any }> = ({ location }) => {
             text={route.text}
             locationHash={location.hash}
             key={route.id}
+            isSection={route.section}
           ></NavItem>
         ))}
       </Flex>

--- a/src/components/header/mobileMenu.tsx
+++ b/src/components/header/mobileMenu.tsx
@@ -28,8 +28,9 @@ export const MobileMenu: React.FC<Props> = ({
             <NavItem
               id={route.id}
               text={route.text}
-              locationHash={location.hash}
+              location={location.href}
               key={route.id}
+              isSection={route.section}
             ></NavItem>
           ))}
         </DrawerBody>

--- a/src/components/header/routes.ts
+++ b/src/components/header/routes.ts
@@ -2,17 +2,21 @@ export const routes = [
   {
     id: "about",
     text: "About",
+    section: true,
   },
   {
     id: "events",
     text: "Events",
+    section: true,
   },
   {
     id: "team",
     text: "Team",
+    section: false,
   },
   {
     id: "contact",
     text: "Contact",
+    section: true,
   },
 ];

--- a/src/components/team/member.tsx
+++ b/src/components/team/member.tsx
@@ -39,7 +39,14 @@ export const Member: FunctionComponent<MemberComponentProps> = ({
   const { name, picture } = memberData;
 
   return (
-    <Flex m={5} direction="column" align="center">
+    <Flex
+      m={5}
+      direction="column"
+      align="center"
+      flexGrow={1}
+      flexShrink={0}
+      flexBasis="21%"
+    >
       <Image my={1} src={picture} alt={name} rounded="full" size={200} />
       <Heading my={1} as="h6" size="sm">
         {name}

--- a/src/components/team/team.tsx
+++ b/src/components/team/team.tsx
@@ -3,11 +3,17 @@ import { Flex, Text } from "@chakra-ui/core";
 import { Member } from "./member";
 import { membersData } from "./membersData";
 
+const teamIntro =
+  "The team at HKU MLS consists of like-minded individuals from diverse backgrounds who are committed to bringing about positive change in society with the power of machine learning and artificial intelligence. Its current members are:";
 export const Team: FunctionComponent = () => {
   return (
     <Flex id="team" align="center" direction="column" p={[4, 6, 8, 10]}>
       <Text fontSize="3xl" as="b" p={5}>
         Team
+      </Text>
+      <Text fontSize={["l", "l", "xl", "xl"]} pb={5}>
+        {" "}
+        {teamIntro}{" "}
       </Text>
       <Flex flexWrap="wrap" justify="center">
         {membersData.map((memberData, index) => (

--- a/src/components/team/team.tsx
+++ b/src/components/team/team.tsx
@@ -1,5 +1,5 @@
 import React, { FunctionComponent } from "react";
-import { Flex, Text } from "@chakra-ui/core";
+import { Flex, Text, Grid } from "@chakra-ui/core";
 import { Member } from "./member";
 import { membersData } from "./membersData";
 
@@ -15,11 +15,12 @@ export const Team: FunctionComponent = () => {
         {" "}
         {teamIntro}{" "}
       </Text>
-      <Flex flexWrap="wrap" justify="center">
+
+      <Grid templateColumns="repeat(auto-fit, minmax(300px, 1fr))" width="100%">
         {membersData.map((memberData, index) => (
           <Member key={index} memberData={memberData} />
         ))}
-      </Flex>
+      </Grid>
     </Flex>
   );
 };

--- a/src/pages/index.tsx
+++ b/src/pages/index.tsx
@@ -20,7 +20,6 @@ const IndexPage = ({ location }) => (
       <Jumbotron />
       <About />
       <Sponsors />
-      <Team />
       <Contact />
     </Layout>
     <Footer />

--- a/src/pages/team.tsx
+++ b/src/pages/team.tsx
@@ -11,7 +11,6 @@ const TeamPage = ({ location }) => (
     <Layout location={location}>
       <SEO title="Team" />
       <Team />
-      <Contact />
     </Layout>
     <Footer />
   </>

--- a/src/pages/team.tsx
+++ b/src/pages/team.tsx
@@ -1,0 +1,20 @@
+import React from "react";
+import { Layout } from "../components";
+import { Contact, Team, Footer } from "../components";
+import SEO from "../components/seo";
+
+// Enable smooth-scroll behaviour
+if (typeof window !== "undefined") require("smooth-scroll")('a[href*="#"]');
+
+const TeamPage = ({ location }) => (
+  <>
+    <Layout location={location}>
+      <SEO title="Team" />
+      <Team />
+      <Contact />
+    </Layout>
+    <Footer />
+  </>
+);
+
+export default TeamPage;


### PR DESCRIPTION
Fixes #16 by adding a new team page to the website.

**Detailed changelog:**

1. Remove team section from index page, and add new link to team page under the About section on the index page.
2. Create new team page with short mockup intro text to team, along with team member profiles. Also adjusted flexbox item properties to space out the member profiles more evenly.