### PR TITLE
Fixes nav link highlight; removes Events link

### DIFF
--- a/src/components/header/header.tsx
+++ b/src/components/header/header.tsx
@@ -1,4 +1,4 @@
-import React from "react";
+import React, { useState } from "react";
 import { Flex, Heading, Text, Box, useDisclosure } from "@chakra-ui/core";
 import { Link as GatsbyLink } from "gatsby";
 import { FiMenu } from "react-icons/fi";
@@ -6,8 +6,12 @@ import { FiMenu } from "react-icons/fi";
 import { routes } from "./routes";
 import { MobileMenu } from "./mobileMenu";
 
-export const NavItem = ({ text, id, location, isSection }) => (
-  <GatsbyLink to={isSection ? `/#${id}` : `/${id}`} key={id}>
+export const NavItem = ({ text, id, location, isSection, updateLocation }) => (
+  <GatsbyLink
+    to={isSection ? `/#${id}` : `/${id}`}
+    key={id}
+    onClick={() => updateLocation(window.location.href)}
+  >
     <Text color={location.endsWith(id) ? "selectedNavColor" : "white"} pr={5}>
       {text}
     </Text>
@@ -15,6 +19,7 @@ export const NavItem = ({ text, id, location, isSection }) => (
 );
 
 export const Header: React.FC<{ location: any }> = ({ location }) => {
+  const [curLocation, setCurLocation] = useState(location.href);
   const disclosure = useDisclosure();
 
   return (
@@ -32,9 +37,10 @@ export const Header: React.FC<{ location: any }> = ({ location }) => {
           <NavItem
             id={route.id}
             text={route.text}
-            location={location.href}
+            location={curLocation}
             key={route.id}
             isSection={route.section}
+            updateLocation={setCurLocation}
           ></NavItem>
         ))}
       </Flex>

--- a/src/components/header/routes.ts
+++ b/src/components/header/routes.ts
@@ -5,11 +5,6 @@ export const routes = [
     section: true,
   },
   {
-    id: "events",
-    text: "Events",
-    section: true,
-  },
-  {
     id: "team",
     text: "Team",
     section: false,


### PR DESCRIPTION
Fixes #12.

**Detailed changelog:**

1. Adds location as state to ensure that nav links receive the updated URL to decide whether they need to be highlighted or not.
2. Removes the "Events" link for the time being, as there currently is no element being rendered with the ID `events`. A future PR adding in an "Events" section could look into bringing the link back in the nav.